### PR TITLE
Check user list does not exceed 1000

### DIFF
--- a/src/zcl_scpms_push_notification.clas.abap
+++ b/src/zcl_scpms_push_notification.clas.abap
@@ -289,6 +289,11 @@ CLASS ZCL_SCPMS_PUSH_NOTIFICATION IMPLEMENTATION.
         EXPORTING
           textid = zcx_scpms_push_notification=>user_list_empty.
 
+    ELSEIF lines( users ) GT 1000.
+      RAISE EXCEPTION TYPE zcx_scpms_push_notification
+        EXPORTING
+          textid = zcx_scpms_push_notification=>user_list_too_big.
+
     ELSEIF notification IS NOT BOUND.
       RAISE EXCEPTION TYPE zcx_scpms_push_notification
         EXPORTING

--- a/src/zcx_scpms_push_notification.clas.abap
+++ b/src/zcx_scpms_push_notification.clas.abap
@@ -107,6 +107,15 @@ public section.
       attr3 type scx_attrname value '',
       attr4 type scx_attrname value '',
     end of CLOSE_CONNECTION_FAILED .
+  constants:
+    begin of USER_LIST_TOO_BIG,
+      msgid type symsgid value 'ZSCPMS_PUSH_NOTIF',
+      msgno type symsgno value '012',
+      attr1 type scx_attrname value '',
+      attr2 type scx_attrname value '',
+      attr3 type scx_attrname value '',
+      attr4 type scx_attrname value '',
+    end of USER_LIST_TOO_BIG .
 
   methods CONSTRUCTOR
     importing

--- a/src/zscpms_push_notif.msag.xml
+++ b/src/zscpms_push_notif.msag.xml
@@ -74,6 +74,12 @@
      <MSGNR>011</MSGNR>
      <TEXT>Close connection failed.</TEXT>
     </T100>
+    <T100>
+     <SPRSL>E</SPRSL>
+     <ARBGB>ZSCPMS_PUSH_NOTIF</ARBGB>
+     <MSGNR>012</MSGNR>
+     <TEXT>List of users cannot exceed 1000 entries per request. Please split table.</TEXT>
+    </T100>
    </T100>
   </asx:values>
  </asx:abap>


### PR DESCRIPTION
CPms API for push notification does not accept more than 1000 users. Add a check for this and raise an exception.